### PR TITLE
Remove hardcoded version numbers from makefile

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -8,8 +8,8 @@ args = ["build", "--release"]
 [tasks.zip]
 script = [
 '''
-zip rota-gen-0.1.1.zip -j config* target/release/rota-korpuss-gen.exe
-echo "Archive generated in rota-gen-0.1.1.zip"
+zip rota-gen-${CARGO_MAKE_CRATE_VERSION}.zip -j config* target/release/rota-korpuss-gen.exe
+echo "Archive generated in rota-gen-${CARGO_MAKE_CRATE_VERSION}.zip"
 '''
 ]
 


### PR DESCRIPTION
This should help out remove any needed maintenance of the makefile.
[Here is a full list of env vars](https://github.com/sagiegurari/cargo-make#global) you get automatically.